### PR TITLE
bump the version `bluesky_text`

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: bluesky_text
-      sha256: "189800c6e7e75c0424cca40099b7492d6bb0493c6225a4eb46805aad5a7ec95a"
+      sha256: "5bc3dc50f7907bc7ba4729bea72c2ffbb4cc3d19a78629dfafd029492e62c384"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   flutter_riverpod: ^2.3.6
   shared_preferences: ^2.1.0
   flutter_svg: ^2.0.5
-  bluesky_text: ^0.4.0
+  bluesky_text: ^0.4.1
   image_picker: ^0.8.7+5
 
 dependency_overrides:


### PR DESCRIPTION
BlueskyTextのv0.4.0で発生したURL検知に関するバグを修正しました。v0.4.1を使用してください。